### PR TITLE
Update game genres and enhance user tests

### DIFF
--- a/test/TC.CloudGames.Domain.Tests/Game/GameTests.cs
+++ b/test/TC.CloudGames.Domain.Tests/Game/GameTests.cs
@@ -23,9 +23,9 @@ public class GameTests
     {
         _faker = new Faker();
 
-        _genres = new List<string> { "Ação", "Aventura", "RPG", "Estratégia", "Simulação", "Corrida", "Esporte", "Puzzle",
-            "Luta", "Plataforma", "FPS", "TPS", "Survival", "Horror", "Stealth", "Mundo Aberto", "MMORPG", "Roguelike",
-            "Visual Novel", "Beat 'em up", "Battle Royale", "Musical", "Party Game", "Metroidvania", "Idle / Incremental",
+        _genres = new List<string> { "Action", "Adventure", "RPG", "Strategy", "Simulation", "Racing", "Sport", "Puzzle",
+            "Fighter", "Platform", "FPS", "TPS", "Survival", "Horror", "Stealth", "Open World", "MMORPG", "Roguelike",
+            "Visual Novel", "Beat 'em up", "Battle Royale", "Musical", "Party Game", "Metroidvania", "Idle/Incremental",
             "Tower Defense", "MOBA", "Sandbox", "Tycoon" };
 
         _platforms = [.. DomainGameDetails.ValidPlatforms];


### PR DESCRIPTION
Refactor `GameTests` to change genre names from Portuguese to English for consistency. Adjusted the `Idle / Incremental` genre to `Idle/Incremental`.

In `UserTests`, modified `using` directives for clarity and added two new test methods to improve coverage: one for invalid user creation with empty fields and another for successful user creation with valid fields. Utilized the `Faker` library for test data generation and included assertions to validate outcomes.