### PR TITLE
Refactor user and game creation with builder pattern

### DIFF
--- a/src/TC.CloudGames.Api/Extensions/SeedDataExtension.cs
+++ b/src/TC.CloudGames.Api/Extensions/SeedDataExtension.cs
@@ -31,31 +31,38 @@ public static class SeedDataExtension
         List<User> users = [];
 
         //Create default users
-        users.Add(await User.CreateAsync(
-                "Admin",
-                "User",
-                "admin@admin.com",
-                "Admin@123",
-                "Admin",
-                userRepository).ConfigureAwait(false));
+        users.Add(await User.CreateAsync(builder =>
+        {
+            builder.FirstName = "Admin";
+            builder.LastName = "User";
+            builder.Email = "admin@admin.com";
+            builder.Password = "Admin@123";
+            builder.Role = "Admin";
+        },
+        userRepository).ConfigureAwait(false));
 
-        users.Add(await User.CreateAsync(
-                "Regular",
-                "User",
-                "user@user.com",
-                "User@123",
-                "User",
-                userRepository).ConfigureAwait(false));
+
+        users.Add(await User.CreateAsync(builder =>
+        {
+            builder.FirstName = "Regular";
+            builder.LastName = "User";
+            builder.Email = "user@user.com";
+            builder.Password = "User@123";
+            builder.Role = "User";
+        },
+        userRepository).ConfigureAwait(false));
 
         for (var i = 0; i < 100; i++)
         {
-            var newUser = await User.CreateAsync(
-                faker.Name.FirstName().OnlyLetters(),
-                faker.Name.LastName().OnlyLetters(),
-                faker.Internet.Email(),
-                PasswordGenerator.GeneratePassword(),
-                faker.PickRandom(Role.ValidRoles.ToArray()),
-                userRepository).ConfigureAwait(false);
+            var newUser = await User.CreateAsync(builder =>
+            {
+                builder.FirstName = faker.Name.FirstName().OnlyLetters();
+                builder.LastName = faker.Name.LastName().OnlyLetters();
+                builder.Email = faker.Internet.Email();
+                builder.Password = PasswordGenerator.GeneratePassword();
+                builder.Role = faker.PickRandom(Role.ValidRoles.ToArray());
+            },
+            userRepository).ConfigureAwait(false);
 
             if (!newUser.IsSuccess) continue;
 

--- a/src/TC.CloudGames.Application/Games/CreateGame/CreateGameCommandValidator.cs
+++ b/src/TC.CloudGames.Application/Games/CreateGame/CreateGameCommandValidator.cs
@@ -52,7 +52,7 @@ namespace TC.CloudGames.Application.Games.CreateGame
         {
             RuleFor(x => x.AgeRating)
                 .NotEmpty()
-                    .WithMessage("Age rating is required.")
+                    .WithMessage("Age rating object is required.")
                     .WithErrorCode($"{nameof(Game.AgeRating)}.Required")
                 .DependentRules(() =>
                 {
@@ -61,11 +61,11 @@ namespace TC.CloudGames.Application.Games.CreateGame
                             .WithMessage("Age rating value is required.")
                             .WithErrorCode($"{nameof(Game.AgeRating)}.Required")
                         .MaximumLength(10)
-                            .WithMessage("Age rating cannot exceed 10 characters.")
+                            .WithMessage("Age rating value cannot exceed 10 characters.")
                             .WithErrorCode($"{nameof(Game.AgeRating)}.MaximumLength");
                 })
                 .Must(rating => AgeRating.ValidRatings.Contains(rating))
-                    .WithMessage($"Invalid age rating specified. Valid age rating are: {AgeRating.ValidRatings.JoinWithQuotes()}.")
+                    .WithMessage($"Invalid age rating value specified. Valid age rating are: {AgeRating.ValidRatings.JoinWithQuotes()}.")
                     .WithErrorCode($"{nameof(Game.AgeRating)}.ValidRating");
         }
 
@@ -81,7 +81,7 @@ namespace TC.CloudGames.Application.Games.CreateGame
         {
             RuleFor(x => x.DeveloperInfo)
                 .NotNull()
-                    .WithMessage("Developer information is required.")
+                    .WithMessage("Developer information object is required.")
                     .WithErrorCode($"{nameof(Game.DeveloperInfo)}.Required")
                 .DependentRules(() =>
                 {
@@ -107,13 +107,13 @@ namespace TC.CloudGames.Application.Games.CreateGame
         {
             RuleFor(x => x.DiskSize)
                 .NotNull()
-                    .WithMessage("Disk size is required.")
+                    .WithMessage("Disk size object is required.")
                     .WithErrorCode($"{nameof(Game.DiskSize)}.Required")
                 .DependentRules(() =>
                 {
                     RuleFor(x => x.DiskSize)
                         .GreaterThan(0)
-                            .WithMessage("Disk size must be greater than 0.")
+                            .WithMessage("Disk size value must be greater than 0.")
                             .WithErrorCode($"{nameof(Game.DiskSize)}.GreaterThanZero");
                 });
         }
@@ -122,13 +122,13 @@ namespace TC.CloudGames.Application.Games.CreateGame
         {
             RuleFor(x => x.Price)
                 .NotNull()
-                    .WithMessage("Price amount is required.")
+                    .WithMessage("Price object is required.")
                     .WithErrorCode($"{nameof(Game.Price)}.Required")
                 .DependentRules(() =>
                 {
                     RuleFor(x => x.Price)
                         .GreaterThanOrEqualTo(0)
-                            .WithMessage("Price must be greater than or equal to 0.")
+                            .WithMessage("Price amount must be greater than or equal to 0.")
                             .WithErrorCode($"{nameof(Game.Price)}.GreaterThanOrEqualToZero");
                 });
         }
@@ -137,7 +137,7 @@ namespace TC.CloudGames.Application.Games.CreateGame
         {
             RuleFor(x => x.Playtime)
                 .Must(playtime => playtime == null || playtime.Hours != null || playtime.PlayerCount != null)
-                    .WithMessage("At least one of Playtime Hours or Player Count must be provided.")
+                    .WithMessage("At least one of Playtime Hours or Player Count must be provided for Playtime object.")
                     .WithErrorCode($"{nameof(Game.Playtime)}.Required")
                 .DependentRules(() =>
                 {
@@ -163,7 +163,7 @@ namespace TC.CloudGames.Application.Games.CreateGame
         {
             RuleFor(x => x.GameDetails)
                 .NotNull()
-                    .WithMessage("Game details are required.")
+                    .WithMessage("Game details object are required.")
                     .WithErrorCode($"{nameof(Game.GameDetails)}.Required")
                 .DependentRules(() =>
                 {
@@ -238,7 +238,7 @@ namespace TC.CloudGames.Application.Games.CreateGame
         {
             RuleFor(x => x.SystemRequirements)
                 .NotNull()
-                    .WithMessage("System requirements are required.")
+                    .WithMessage("System requirements object are required.")
                     .WithErrorCode($"{nameof(Game.SystemRequirements)}.Required")
                 .DependentRules(() =>
                 {
@@ -258,10 +258,10 @@ namespace TC.CloudGames.Application.Games.CreateGame
             {
                 RuleFor(x => x.Rating!)
                     .GreaterThanOrEqualTo(0)
-                        .WithMessage("Rating must be greater than or equal to 0.")
+                        .WithMessage("Rating value must be greater than or equal to 0.")
                         .WithErrorCode($"{nameof(Game.Rating)}.GreaterThanOrEqualToZero")
                     .LessThanOrEqualTo(10)
-                        .WithMessage("Rating must be less than or equal to 10.")
+                        .WithMessage("Rating value must be less than or equal to 10.")
                         .WithErrorCode($"{nameof(Game.Rating)}.LessThanOrEqualToTen");
             });
         }

--- a/src/TC.CloudGames.Application/Users/CreateUser/CreateUserMapper.cs
+++ b/src/TC.CloudGames.Application/Users/CreateUser/CreateUserMapper.cs
@@ -7,14 +7,15 @@ public static class CreateUserMapper
 {
     public static async Task<Result<User>> ToEntityAsync(CreateUserCommand r, IUserEfRepository userEfRepository)
     {
-        return await User.CreateAsync(
-            firstName: r.FirstName,
-            lastName: r.LastName,
-            email: r.Email,
-            password: r.Password,
-            role: r.Role,
-            userEfRepository
-        );
+        return await User.CreateAsync(builder =>
+        {
+            builder.FirstName = r.FirstName;
+            builder.LastName = r.LastName;
+            builder.Email = r.Email;
+            builder.Password = r.Password;
+            builder.Role = r.Role;
+        },
+        userEfRepository).ConfigureAwait(false);
     }
 
     public static CreateUserResponse FromEntity(User e)

--- a/src/TC.CloudGames.Domain/Game/Abstractions/CreateGameValidator.cs
+++ b/src/TC.CloudGames.Domain/Game/Abstractions/CreateGameValidator.cs
@@ -14,7 +14,7 @@
             ValidatePlaytime();
             ValidateGameDetails();
             ValidateSystemRequirements();
-            ValidateRating();
+            //ValidateRating();
             ValidateGameStatus();
             ValidateOfficialLink();
         }

--- a/src/TC.CloudGames.Domain/Game/Abstractions/GameEntityValidator.cs
+++ b/src/TC.CloudGames.Domain/Game/Abstractions/GameEntityValidator.cs
@@ -10,13 +10,9 @@ namespace TC.CloudGames.Domain.Game.Abstractions
                 .NotEmpty()
                     .WithMessage("Game name is required.")
                     .WithErrorCode($"{nameof(Game.Name)}.Required")
-                .DependentRules(() =>
-                {
-                    RuleFor(x => x.Name)
-                        .MaximumLength(200)
-                            .WithMessage("Name cannot exceed 200 characters.")
-                            .WithErrorCode($"{nameof(Game.Name)}.MaximumLength");
-                });
+                .MaximumLength(200)
+                    .WithMessage("Name cannot exceed 200 characters.")
+                    .WithErrorCode($"{nameof(Game.Name)}.MaximumLength");
         }
 
         protected void ValidateReleaseDate()
@@ -34,7 +30,7 @@ namespace TC.CloudGames.Domain.Game.Abstractions
         {
             RuleFor(x => x.AgeRating)
                 .NotEmpty()
-                    .WithMessage("Age rating is required.")
+                    .WithMessage("Age rating object is required.")
                     .WithErrorCode($"{nameof(Game.AgeRating)}.Required");
         }
 
@@ -50,7 +46,7 @@ namespace TC.CloudGames.Domain.Game.Abstractions
         {
             RuleFor(x => x.DeveloperInfo)
                 .NotNull()
-                    .WithMessage("Developer information is required.")
+                    .WithMessage("Developer information object is required.")
                     .WithErrorCode($"{nameof(Game.DeveloperInfo)}.Required");
         }
 
@@ -58,7 +54,7 @@ namespace TC.CloudGames.Domain.Game.Abstractions
         {
             RuleFor(x => x.DiskSize)
                 .NotNull()
-                    .WithMessage("Disk size is required.")
+                    .WithMessage("Disk size object is required.")
                     .WithErrorCode($"{nameof(Game.DiskSize)}.Required");
         }
 
@@ -66,7 +62,7 @@ namespace TC.CloudGames.Domain.Game.Abstractions
         {
             RuleFor(x => x.Price)
                 .NotNull()
-                    .WithMessage("Price is required.")
+                    .WithMessage("Price object is required.")
                     .WithErrorCode($"{nameof(Game.Price)}.Required");
         }
 
@@ -74,7 +70,7 @@ namespace TC.CloudGames.Domain.Game.Abstractions
         {
             RuleFor(x => x.Playtime)
                 .Must(playtime => playtime == null || playtime.Hours != null || playtime.PlayerCount != null)
-                    .WithMessage("Playtime Hours or Player Count must be provided if specified.")
+                    .WithMessage("Playtime Hours or Player Count must be provided if playtime object specified.")
                     .WithErrorCode($"{nameof(Game.Playtime)}.RequiredConditional");
         }
 
@@ -82,35 +78,26 @@ namespace TC.CloudGames.Domain.Game.Abstractions
         {
             RuleFor(x => x.GameDetails)
                 .NotNull()
-                    .WithMessage("Game details are required.")
+                    .WithMessage("Game details object are required.")
                     .WithErrorCode($"{nameof(Game.GameDetails)}.Required");
         }
 
         protected void ValidateSystemRequirements()
         {
             RuleFor(x => x.SystemRequirements)
-                .NotNull().WithMessage("System requirements are required.").WithErrorCode($"{nameof(Game.SystemRequirements)}.Required")
-                .DependentRules(() =>
-                {
-                    RuleFor(x => x.SystemRequirements.Minimum)
-                        .NotEmpty()
-                            .WithMessage("Minimum system requirements are required.")
-                            .WithErrorCode($"{nameof(Game.SystemRequirements.Minimum)}.Required")
-                        .MaximumLength(1000)
-                            .WithMessage("Minimum system requirements must not exceed 1000 characters.")
-                            .WithErrorCode($"{nameof(Game.SystemRequirements.Minimum)}.MaximumLength");
-                });
+                .NotNull().WithMessage("System requirements object are required.").WithErrorCode($"{nameof(Game.SystemRequirements)}.Required");
         }
 
         protected void ValidateRating()
         {
-            When(x => x.Rating != null && x.Rating.Average.HasValue, () =>
-            {
-                RuleFor(x => x.Rating!.Average)
-                    .GreaterThan(0)
-                        .WithMessage("Rating must be greater than 0.")
-                        .WithErrorCode($"{nameof(Game.Rating)}.GreaterThanZero");
-            });
+            //because Rating is nullable, agreggate root should not validate something that the value object it self should validate
+            //When(x => x.Rating != null && x.Rating.Average.HasValue, () =>
+            //{
+            //    RuleFor(x => x.Rating!.Average)
+            //        .GreaterThan(0)
+            //            .WithMessage("Rating must be greater than 0.")
+            //            .WithErrorCode($"{nameof(Game.Rating)}.GreaterThanZero");
+            //});
         }
 
         protected void ValidateGameStatus()

--- a/src/TC.CloudGames.Domain/Game/AgeRating.cs
+++ b/src/TC.CloudGames.Domain/Game/AgeRating.cs
@@ -59,11 +59,11 @@ namespace TC.CloudGames.Domain.Game
                     .WithErrorCode($"{nameof(AgeRating)}.Required")
                     .OverridePropertyName(nameof(AgeRating))
                 .MaximumLength(10)
-                    .WithMessage("Age rating cannot exceed 10 characters.")
+                    .WithMessage("Age rating value cannot exceed 10 characters.")
                     .WithErrorCode($"{nameof(Game.AgeRating)}.MaximumLength")
                     .OverridePropertyName(nameof(AgeRating))
                 .Must(rating => AgeRating.ValidRatings.Contains(rating))
-                    .WithMessage($"Invalid age rating specified. Valid age rating are: {AgeRating.ValidRatings.JoinWithQuotes()}.")
+                    .WithMessage($"Invalid age rating value specified. Valid age rating are: {AgeRating.ValidRatings.JoinWithQuotes()}.")
                     .WithErrorCode($"{nameof(AgeRating)}.ValidRating")
                     .OverridePropertyName(nameof(AgeRating));
         }

--- a/src/TC.CloudGames.Domain/Game/DiskSize.cs
+++ b/src/TC.CloudGames.Domain/Game/DiskSize.cs
@@ -48,11 +48,11 @@
             {
                 RuleFor(x => x.SizeInGb)
                     .NotEmpty()
-                        .WithMessage("Disk size is required.")
+                        .WithMessage("Disk size value is required.")
                         .WithErrorCode($"{nameof(DiskSize)}.Required")
                         .OverridePropertyName(nameof(DiskSize))
                     .GreaterThan(0)
-                        .WithMessage("Disk size must be greater than 0.")
+                        .WithMessage("Disk size value must be greater than 0.")
                         .WithErrorCode($"{nameof(DiskSize)}.GreaterThanZero")
                         .OverridePropertyName(nameof(DiskSize));
             }

--- a/src/TC.CloudGames.Domain/Game/Price.cs
+++ b/src/TC.CloudGames.Domain/Game/Price.cs
@@ -55,7 +55,7 @@
                     .WithErrorCode($"{nameof(Price)}.Required")
                     .OverridePropertyName(nameof(Price))
                 .GreaterThanOrEqualTo(0)
-                    .WithMessage("Price must be greater than or equal to 0.")
+                    .WithMessage("Price amount must be greater than or equal to 0.")
                     .WithErrorCode($"{nameof(Price)}.GreaterThanOrEqualToZero")
                     .OverridePropertyName(nameof(Price));
         }

--- a/src/TC.CloudGames.Domain/Game/Rating.cs
+++ b/src/TC.CloudGames.Domain/Game/Rating.cs
@@ -53,11 +53,11 @@ namespace TC.CloudGames.Domain.Game
             {
                 RuleFor(x => x.Average)
                     .GreaterThanOrEqualTo(0)
-                        .WithMessage("Rating must be greater than or equal to 0.")
+                        .WithMessage("Rating value must be greater than or equal to 0.")
                         .WithErrorCode($"{nameof(Rating)}.GreaterThanOrEqualToZero")
                         .OverridePropertyName(nameof(Rating))
                     .LessThanOrEqualTo(10)
-                        .WithMessage("Average rating must be less than or equal to 10.")
+                        .WithMessage("Rating value must be less than or equal to 10.")
                         .WithErrorCode($"{nameof(Rating)}.LessThanOrEqualToTen")
                         .OverridePropertyName(nameof(Rating));
             });

--- a/src/TC.CloudGames.Domain/User/Abstractions/CreateUserValidator.cs
+++ b/src/TC.CloudGames.Domain/User/Abstractions/CreateUserValidator.cs
@@ -7,6 +7,9 @@
             ValidateId();
             ValidateFirstName();
             ValidateLastName();
+            ValidateEmail();
+            ValidatePassword();
+            ValidateRole();
         }
     }
 }

--- a/src/TC.CloudGames.Domain/User/Abstractions/UserEntityValidator.cs
+++ b/src/TC.CloudGames.Domain/User/Abstractions/UserEntityValidator.cs
@@ -22,6 +22,9 @@
                 .MinimumLength(3)
                     .WithMessage("First name must be at least 3 characters long.")
                     .WithErrorCode($"{nameof(User.FirstName)}.MinimumLength")
+                .MaximumLength(200)
+                    .WithMessage("First name must be at most 200 characters long.")
+                    .WithErrorCode($"{nameof(User.FirstName)}.MaximumLength")
                 .Matches(@"^[a-zA-Z]+$")
                     .WithMessage("First name can only contain letters.")
                     .WithErrorCode($"{nameof(User.FirstName)}.InvalidCharacters");
@@ -36,9 +39,36 @@
                 .MinimumLength(3)
                     .WithMessage("Last name must be at least 3 characters long.")
                     .WithErrorCode($"{nameof(User.LastName)}.MinimumLength")
+                .MaximumLength(200)
+                    .WithMessage("Last name must be at most 200 characters long.")
+                    .WithErrorCode($"{nameof(User.LastName)}.MaximumLength")
                 .Matches(@"^[a-zA-Z]+$")
                     .WithMessage("Last name can only contain letters.")
                     .WithErrorCode($"{nameof(User.LastName)}.InvalidCharacters");
+        }
+
+        protected void ValidateEmail()
+        {
+            RuleFor(x => x.Email)
+                .NotEmpty()
+                    .WithMessage("Email object is required.")
+                    .WithErrorCode($"{nameof(User.Email)}.Required");
+        }
+
+        protected void ValidatePassword()
+        {
+            RuleFor(x => x.Password)
+                .NotEmpty()
+                    .WithMessage("Password object is required.")
+                    .WithErrorCode($"{nameof(User.Password)}.Required");
+        }
+
+        protected void ValidateRole()
+        {
+            RuleFor(x => x.Role)
+                .NotEmpty()
+                    .WithMessage("Role object is required.")
+                    .WithErrorCode($"{nameof(User.Role)}.Required");
         }
     }
 }

--- a/src/TC.CloudGames.Domain/User/Email.cs
+++ b/src/TC.CloudGames.Domain/User/Email.cs
@@ -76,6 +76,10 @@ namespace TC.CloudGames.Domain.User
                 .MustAsync(async (email, cancellation) => !await _userEfRepository.EmailExistsAsync(email, cancellation))
                     .WithMessage("Email already exists.")
                     .WithErrorCode($"{nameof(Email)}.AlreadyExists")
+                    .OverridePropertyName(nameof(Email))
+                .MaximumLength(200)
+                    .WithMessage("Email cannot exceed 200 characters.")
+                    .WithErrorCode($"{nameof(User.Email)}.MaximumLength")
                     .OverridePropertyName(nameof(Email));
         }
     }

--- a/src/TC.CloudGames.Domain/User/Password.cs
+++ b/src/TC.CloudGames.Domain/User/Password.cs
@@ -83,6 +83,10 @@ namespace TC.CloudGames.Domain.User
                 .Matches(@"[\W_]")
                     .WithMessage("Password must contain at least one special character.")
                     .WithErrorCode($"{nameof(Password)}.SpecialCharacter")
+                    .OverridePropertyName(nameof(Password))
+                .MaximumLength(200)
+                    .WithMessage("Password cannot exceed 200 characters.")
+                    .WithErrorCode($"{nameof(Password)}.MaximumLength")
                     .OverridePropertyName(nameof(Password));
         }
     }

--- a/src/TC.CloudGames.Domain/User/Role.cs
+++ b/src/TC.CloudGames.Domain/User/Role.cs
@@ -57,6 +57,10 @@ namespace TC.CloudGames.Domain.User
                 .Must(role => Role.ValidRoles.Contains(role))
                     .WithMessage($"Invalid role specified. Valid roles are: {Role.ValidRoles.JoinWithQuotes()}.")
                     .WithErrorCode($"{nameof(Role)}.InvalidRole")
+                    .OverridePropertyName(nameof(Role))
+                .MaximumLength(20)
+                    .WithMessage("Role cannot exceed 20 characters.")
+                    .WithErrorCode($"{nameof(Role)}.MaximumLength")
                     .OverridePropertyName(nameof(Role));
         }
     }

--- a/test/TC.CloudGames.Api.Tests/TC.CloudGames.Api.Tests.csproj
+++ b/test/TC.CloudGames.Api.Tests/TC.CloudGames.Api.Tests.csproj
@@ -21,11 +21,6 @@
     </PackageReference>
     <PackageReference Include="FastEndpoints.Testing" Version="6.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.10.0.116381">
       <PrivateAssets>all</PrivateAssets>

--- a/test/TC.CloudGames.Domain.Tests/TC.CloudGames.Domain.Tests.csproj
+++ b/test/TC.CloudGames.Domain.Tests/TC.CloudGames.Domain.Tests.csproj
@@ -8,17 +8,18 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.1" />
+      <PackageReference Include="FakeItEasy" Version="8.3.0" />
+      <PackageReference Include="FakeItEasy.Analyzer.CSharp" Version="6.1.1">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
         <PackageReference Include="Bogus" Version="35.6.3" />
         <PackageReference Include="coverlet.collector" Version="6.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="Shouldly" Version="4.3.0" />
         <PackageReference Include="SonarAnalyzer.CSharp" Version="10.10.0.116381">
           <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This pull request introduces significant improvements to user creation and validation logic across multiple files, focusing on enhancing readability, consistency, and error handling. Key updates include refactoring user creation to use a builder pattern, improving validation messages for better clarity, and adding helper methods for robust error handling.

### User Creation Refactor:
* Refactored `User.CreateAsync` calls in `SeedDataExtension.cs` and `CreateUserMapper.cs` to use a builder pattern, improving readability and maintainability. [[1]](diffhunk://#diff-28e792f7b9d55313d80dc57f9db35c5009b3a89d1ab18a0898af29437204c3bcL34-R64) [[2]](diffhunk://#diff-e5a31679702339b5a6e076da29ed1e385d13c059d0e1e70847b202ca5a32e21fL10-R18)

### Validation Message Improvements:
* Updated validation messages across `CreateGameCommandValidator.cs` and domain validators to provide more precise and consistent descriptions, such as specifying "object" or "value" in error messages. [[1]](diffhunk://#diff-56c8c21d56d68a3c5c81c0a9a928d76d777b200cba8729ab6ae93acde9999ae2L55-R55) [[2]](diffhunk://#diff-56c8c21d56d68a3c5c81c0a9a928d76d777b200cba8729ab6ae93acde9999ae2L110-R116) [[3]](diffhunk://#diff-390c47ab9fbc346746cb8e453c5e06c385542e0403f4b016e862807b6126d0a7L53-R100)

### Error Handling Enhancements:
* Added `EnsureResult` helper methods in `Entity.cs` to ensure non-null results and provide detailed error messages for value object creation failures.

### Simplifications and Removals:
* Removed unnecessary dependent rules and validations, such as the `ValidateRating` method in `CreateGameValidator.cs` and redundant rules in `GameEntityValidator.cs`. [[1]](diffhunk://#diff-26cdda1748ef301f1b7cf5e28a94eb92106e931e5a1cd5c6f484032b579bed35L17-R17) [[2]](diffhunk://#diff-390c47ab9fbc346746cb8e453c5e06c385542e0403f4b016e862807b6126d0a7L13-L19)

### Domain-Specific Validation Adjustments:
* Adjusted validation logic in domain-specific classes like `AgeRating` and `DiskSize` to align with the updated message format and ensure consistency. [[1]](diffhunk://#diff-b50a347c8b708a3316f16226cf49f24fda51235c61896369c78c296b52dde25fL62-R66) [[2]](diffhunk://#diff-3db32adc0b673b8c1b9c89814f0d4ab43dcc257cee4156a4c4417ce6ec82ee7aL51-R55)