### PR TITLE
Add Grafana Prometheus API token and enhance logging

### DIFF
--- a/.github/workflows/ci_cd_deploy_workflow.yml
+++ b/.github/workflows/ci_cd_deploy_workflow.yml
@@ -387,7 +387,7 @@ jobs:
             db-password,db-host,db-port,db-name,db-admin-login,
             cache-password,cache-host,cache-port,
             otel-auth-header,grafana-api-token,grafana-endpoint,
-            grafana-protocol,grafana-resource-attributes
+            grafana-protocol,grafana-resource-attributes,grafana-prometheus-api-token
         env:
           AZURE_CLIENT_ID: ${{ fromJson(secrets.MAIN_AZURE_CREDENTIALS).clientId }}
           AZURE_TENANT_ID: ${{ fromJson(secrets.MAIN_AZURE_CREDENTIALS).tenantId }}
@@ -425,6 +425,7 @@ jobs:
           CACHE_PASSWORD: ${{ steps.fetch-secrets.outputs['cache-password'] }}
           OTEL_AUTH_HEADER: ${{ steps.fetch-secrets.outputs['otel-auth-header'] }}
           GRAFANA_API_TOKEN: ${{ steps.fetch-secrets.outputs['grafana-api-token'] }}
+          GRAFANA_PROMETHEUS_TOKEN: ${{ steps.fetch-secrets.outputs['grafana-prometheus-api-token'] }}
         run: |
           echo "💾 Updating Container App secrets..."
           az containerapp secret set \
@@ -434,7 +435,8 @@ jobs:
               db-password-secret="$DB_PASSWORD" \
               cache-password-secret="$CACHE_PASSWORD" \
               otel-auth-header-secret="$OTEL_AUTH_HEADER" \
-              grafana-api-token-secret="$GRAFANA_API_TOKEN"
+              grafana-api-token-secret="$GRAFANA_API_TOKEN" \
+              grafana-prometheus-api-token-secret="$GRAFANA_PROMETHEUS_TOKEN"
           echo "✅ Secrets updated successfully"
 
       - name: 🐳 Login to ACR
@@ -481,6 +483,7 @@ jobs:
             OTEL_EXPORTER_OTLP_PROTOCOL=${{ steps.fetch-secrets.outputs['grafana-protocol'] }}
             OTEL_EXPORTER_OTLP_HEADERS=secretref:otel-auth-header-secret
             GRAFANA_API_TOKEN=secretref:grafana-api-token-secret
+            GRAFANA_PROMETHEUS_TOKEN=secretref:grafana-prometheus-api-token-secret
             OTEL_RESOURCE_ATTRIBUTES=${{ steps.fetch-secrets.outputs['grafana-resource-attributes'] }}
 
       - name: 🩺 Enhanced health check with retries

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
       - OTEL_EXPORTER_OTLP_HEADERS=${OTEL_EXPORTER_OTLP_HEADERS}
       - GRAFANA_API_TOKEN=${GRAFANA_API_TOKEN}
+      - GRAFANA_PROMETHEUS_TOKEN=${GRAFANA_PROMETHEUS_TOKEN}
       - OTEL_RESOURCE_ATTRIBUTES=service.name=tccloudgames-app,service.namespace=tccloudgames-app-group,deployment.environment=development
       
   tc-cloudgames-db:

--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -253,6 +253,16 @@ resource "azurerm_key_vault_secret" "key_vault_secret_otel_auth_header" {
   ]
 }
 
+resource "azurerm_key_vault_secret" "key_vault_secret_grafana_prometheus_api_token" {
+  key_vault_id = azurerm_key_vault.key_vault.id
+  name         = "grafana-prometheus-api-token"
+  value        = var.grafana_open_tl_prometheus
+
+  depends_on = [
+    azurerm_key_vault.key_vault
+  ]
+}
+
 # =============================================================================
 # Database Configuration Secrets
 # =============================================================================
@@ -493,6 +503,10 @@ resource "azurerm_container_app" "container_app" {
     value = "placeholder-updated-by-cicd"
   }
   secret {
+    name  = "grafana-prometheus-api-token-secret"
+    value = "placeholder-updated-by-cicd"
+  }
+  secret {
     name  = "grafana-api-token-secret"
     value = "placeholder-updated-by-cicd"
   }
@@ -560,6 +574,10 @@ resource "azurerm_container_app" "container_app" {
       env {
         name        = "GRAFANA_API_TOKEN"
         secret_name = "grafana-api-token-secret"
+      }
+      env {
+        name        = "GRAFANA_PROMETHEUS_TOKEN"
+        secret_name = "grafana-prometheus-api-token-secret"
       }
       env {
         name  = "OTEL_EXPORTER_OTLP_ENDPOINT"

--- a/infra/terraform/dev/variables.tf
+++ b/infra/terraform/dev/variables.tf
@@ -95,3 +95,9 @@ variable "grafana_open_tl_auth_header" {
   description = "Grafana OpenTL authentication header API key"
   sensitive   = true
 }
+
+variable "grafana_open_tl_prometheus" {
+  type        = string
+  description = "Grafana Cloud Prometheus API token for metrics ingestion"
+  sensitive   = true
+}

--- a/src/TC.CloudGames.Api/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/TC.CloudGames.Api/Extensions/ApplicationBuilderExtensions.cs
@@ -83,7 +83,7 @@ internal static class ApplicationBuilderExtensions
                 ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
             })
             // Add Prometheus metrics endpoint
-            .UseOpenTelemetryPrometheusScrapingEndpoint();
+            .UseOpenTelemetryPrometheusScrapingEndpoint("/metrics");
 
         return app;
     }

--- a/src/TC.CloudGames.Api/Extensions/MetricsAuthenticationExtensions.cs
+++ b/src/TC.CloudGames.Api/Extensions/MetricsAuthenticationExtensions.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace TC.CloudGames.Api.Extensions
+{
+    public static class MetricsAuthenticationExtensions
+    {
+        public static IApplicationBuilder UseMetricsAuthentication(this IApplicationBuilder app)
+        {
+            return app.Use(async (context, next) =>
+            {
+                if (context.Request.Path == "/metrics")
+                {
+                    var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
+                    if (authHeader?.StartsWith("Bearer ") == true)
+                    {
+                        var token = authHeader.Substring("Bearer ".Length).Trim();
+                        var expectedToken = Environment.GetEnvironmentVariable("GRAFANA_PROMETHEUS_TOKEN");
+
+                        if (token == expectedToken)
+                        {
+                            await next();
+                            return;
+                        }
+                    }
+
+                    context.Response.StatusCode = 401;
+                    await context.Response.WriteAsync("Unauthorized");
+                    return;
+                }
+
+                await next();
+            });
+        }
+    }
+}

--- a/src/TC.CloudGames.Api/Extensions/SerilogExtensions.cs
+++ b/src/TC.CloudGames.Api/Extensions/SerilogExtensions.cs
@@ -32,7 +32,7 @@ namespace TC.CloudGames.Api.Extensions
                 loggerConfiguration.Enrich.WithProperty("service.namespace", TelemetryConstants.ServiceNamespace);
                 loggerConfiguration.Enrich.WithProperty("service.version", serviceVersion);
                 loggerConfiguration.Enrich.WithProperty("deployment.environment", environment);
-                
+
                 // Additional OpenTelemetry resource attributes for consistency
                 loggerConfiguration.Enrich.WithProperty("cloud.provider", "azure");
                 loggerConfiguration.Enrich.WithProperty("cloud.platform", "azure_container_apps");
@@ -45,7 +45,7 @@ namespace TC.CloudGames.Api.Extensions
                 });
 
                 // Console sink for local/dev visibility
-                loggerConfiguration.WriteTo.Console();
+                loggerConfiguration.WriteTo.Console(new Serilog.Formatting.Json.JsonFormatter()); // Optional for local
 
                 // Loki sink with FIXED label naming (underscores for Grafana Cloud compatibility)
                 var serilogUsing = configuration.GetSection("Serilog:Using").Get<string[]>() ?? [];

--- a/src/TC.CloudGames.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/TC.CloudGames.Api/Extensions/ServiceCollectionExtensions.cs
@@ -62,17 +62,6 @@ public static class ServiceCollectionExtensions
             options.AddOtlpExporter();
         });
 
-        // Add structured JSON logging for better parsing in Grafana
-        builder.Logging.AddJsonConsole(options =>
-        {
-            options.IncludeScopes = true;
-            options.TimestampFormat = "yyyy-MM-dd HH:mm:ss.fff ";
-            options.JsonWriterOptions = new System.Text.Json.JsonWriterOptions
-            {
-                Indented = false
-            };
-        });
-
         return builder;
     }
 

--- a/src/TC.CloudGames.Api/Program.cs
+++ b/src/TC.CloudGames.Api/Program.cs
@@ -5,9 +5,6 @@ var builder = WebApplication.CreateBuilder(args);
 
 DotNetEnv.Env.Load(Path.Combine("./", ".env"));
 
-// DEBUG: Log telemetry configuration
-TelemetryConstants.LogTelemetryConfiguration();
-
 builder.Host.UseCustomSerilog(builder.Configuration);
 
 ServiceCollectionExtensions.ConfigureFluentValidationGlobals();
@@ -24,6 +21,13 @@ builder.Services
    .AddCustomHealthCheck();
 
 var app = builder.Build();
+
+// Get logger instance for Program and log telemetry configuration
+var logger = app.Services.GetRequiredService<ILogger<TC.CloudGames.Api.Program>>();
+TelemetryConstants.LogTelemetryConfiguration(logger);
+
+// Use metrics authentication middleware extension
+app.UseMetricsAuthentication();
 
 app.UseAuthentication()
   .UseAuthorization()

--- a/src/TC.CloudGames.Api/Telemetry/TelemetryConstants.cs
+++ b/src/TC.CloudGames.Api/Telemetry/TelemetryConstants.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace TC.CloudGames.Api.Telemetry;
 
 /// <summary>
@@ -47,17 +49,38 @@ public static class TelemetryConstants
     public const string DatabaseComponent = "database";
     public const string CacheComponent = "cache";
 
-    // Debug Info
-    public static void LogTelemetryConfiguration()
+    /// <summary>
+    /// Logs telemetry configuration details using Microsoft.Extensions.Logging.ILogger
+    /// </summary>
+    public static void LogTelemetryConfiguration(Microsoft.Extensions.Logging.ILogger logger)
     {
-        Console.WriteLine($"=== TELEMETRY DEBUG INFO ===");
-        Console.WriteLine($"Service Name: {ServiceName}");
-        Console.WriteLine($"Service Namespace: {ServiceNamespace}");
-        Console.WriteLine($"Correlation Header: {CorrelationIdHeader}");
-        Console.WriteLine($"Game Meter: {GameMeterName}");
-        Console.WriteLine($"User Meter: {UserMeterName}");
-        Console.WriteLine($"Game Activity Source: {GameActivitySource}");
-        Console.WriteLine($"User Activity Source: {UserActivitySource}");
-        Console.WriteLine($"============================");
+        logger.LogInformation("=== TELEMETRY DEBUG INFO ===");
+        logger.LogInformation("Service Name: {ServiceName}", ServiceName);
+        logger.LogInformation("Service Namespace: {ServiceNamespace}", ServiceNamespace);
+        logger.LogInformation("Telemetry Version: {Version}", Version);
+        logger.LogInformation("Correlation Header: {CorrelationIdHeader}", CorrelationIdHeader);
+        logger.LogInformation("Game Meter: {GameMeterName}", GameMeterName);
+        logger.LogInformation("User Meter: {UserMeterName}", UserMeterName);
+        logger.LogInformation("Game Activity Source: {GameActivitySource}", GameActivitySource);
+        logger.LogInformation("User Activity Source: {UserActivitySource}", UserActivitySource);
+        logger.LogInformation("Database Activity Source: {DatabaseActivitySource}", DatabaseActivitySource);
+        logger.LogInformation("Cache Activity Source: {CacheActivitySource}", CacheActivitySource);
+        logger.LogInformation("Environment: {Environment}", Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "NOT SET");
+        logger.LogInformation("Machine Name: {MachineName}", Environment.MachineName);
+        logger.LogInformation("Container Name: {ContainerName}", Environment.GetEnvironmentVariable("HOSTNAME") ?? "NOT SET");
+
+        // OTLP Configuration Debug (no sensitive values)
+        var otlpEndpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT");
+        var otlpHeaders = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_HEADERS");
+        var otlpProtocol = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_PROTOCOL");
+        var grafanaApiToken = Environment.GetEnvironmentVariable("GRAFANA_API_TOKEN");
+        var grafanaPrometheusToken = Environment.GetEnvironmentVariable("GRAFANA_PROMETHEUS_TOKEN");
+
+        logger.LogInformation("OTLP Endpoint: {OtlpEndpoint}", string.IsNullOrEmpty(otlpEndpoint) ? "NOT SET" : otlpEndpoint);
+        logger.LogInformation("OTLP Headers: {OtlpHeaders}", string.IsNullOrEmpty(otlpHeaders) ? "NOT SET" : "***CONFIGURED***");
+        logger.LogInformation("OTLP Protocol: {OtlpProtocol}", string.IsNullOrEmpty(otlpProtocol) ? "NOT SET" : otlpProtocol);
+        logger.LogInformation("Grafana API Token: {GrafanaApiToken}", string.IsNullOrEmpty(grafanaApiToken) ? "NOT SET" : "***CONFIGURED***");
+        logger.LogInformation("Grafana Prometheus Token: {GrafanaPrometheusToken}", string.IsNullOrEmpty(grafanaPrometheusToken) ? "NOT SET" : "***CONFIGURED***");
+        logger.LogInformation("============================");
     }
 }


### PR DESCRIPTION
This commit introduces a new Grafana Prometheus API token across various configuration files, including the CI/CD workflow, Docker Compose, Terraform scripts, and C# application code. The token is integrated into environment variables, secrets management, and logging configurations. Additionally, a new middleware for metrics authentication is added to improve security for the Prometheus metrics endpoint. The logging mechanism is updated to provide more detailed telemetry information, including the new token.